### PR TITLE
Fix `competition_from_ctx`

### DIFF
--- a/src/commands/competition.rs
+++ b/src/commands/competition.rs
@@ -90,18 +90,21 @@ pub async fn competition(
 
 /// Gets the competition in the channel the command was invoked from.
 pub async fn get_competition_from_ctx(ctx: &CmdContext<'_>) -> Result<Competition, Error> {
-    let channel_id = ctx.channel_id();
-    get_competition_from_id(ctx, channel_id).await
-}
+    let Some(thread_channel) = ctx.guild_channel().await else {
+        Err(anyhow::anyhow!("You are not inside a competition channel."))?
+    };
 
-/// Gets the competition in the given channel.
-pub async fn get_competition_from_id(ctx: &CmdContext<'_>, channel_id: ChannelId) -> Result<Competition, Error> {
+    // For a forum channel, the competition channel will be the command channel's parent.
+    let Some(channel_id) = thread_channel.parent_id else {
+        Err(anyhow::anyhow!("You are not inside a competition channel."))?
+    };
+
     let competition = ctx
         .data()
         .db
         .get_competition(channel_id)
         .await
-        .with_context(|| "Not in a competition channel.")?;
+        .with_context(|| "You are not inside a competition channel.")?;
 
     Ok(competition)
 }


### PR DESCRIPTION
Realized that the change to forum channels broke bingo, so this should theoretically fix + standardize everything.